### PR TITLE
Make satisfaction ratings incremental

### DIFF
--- a/tap_zendesk/default_config.json
+++ b/tap_zendesk/default_config.json
@@ -1,5 +1,5 @@
 {
-  "rate_limit": 1000,
+  "rate_limit": 20,
   "max_workers": 10,
   "batch_size": 50
 }

--- a/tap_zendesk/default_config.json
+++ b/tap_zendesk/default_config.json
@@ -1,5 +1,5 @@
 {
-  "rate_limit": 20,
+  "rate_limit": 1000,
   "max_workers": 10,
   "batch_size": 50
 }

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -365,15 +365,21 @@ class SatisfactionRatings(Stream):
 
     def sync(self, state):
         bookmark = self.get_bookmark(state)
-
-        satisfaction_ratings = self.client.satisfaction_ratings()
+        bookmark_epoch = int(bookmark.strftime('%s'))
+        # We substract a second here because the API seems to compare
+        # start_time with a >, but we typically prefer a >= behavior.
+        # Also, the start_time query parameter filters based off of
+        # created_at, but zendesk support confirmed with us that
+        # satisfaction_ratings are immutable so that created_at =
+        # updated_at
+        satisfaction_ratings = self.client.satisfaction_ratings(start_time=(bookmark_epoch-1))
         for satisfaction_rating in satisfaction_ratings:
             if utils.strptime_with_tz(satisfaction_rating.updated_at) >= bookmark:
                 # NB: We don't trust that the records come back ordered by
                 # updated_at (we've observed out-of-order records),
                 # so we can't save state until we've seen all records
                 self.update_bookmark(state, satisfaction_rating.updated_at)
-                yield (self.stream, satisfaction_rating)
+            yield (self.stream, satisfaction_rating)
 
 class Groups(Stream):
     name = "groups"


### PR DESCRIPTION
# Description of change
Change satisfaction ratings to be incremental, nicked from https://github.com/singer-io/tap-zendesk/pull/37. Our sync currently takes 6 hours as it does a full refresh each time!

A rebase on `singer-io/tap-zendesk` would probably be best.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
